### PR TITLE
rename compressor params

### DIFF
--- a/lib/timber_takt.lua
+++ b/lib/timber_takt.lua
@@ -523,15 +523,15 @@ function Timber.add_params()
 
   params:add_separator()
 
-  params:add_control("comp_level", "Comp. level", specs.COMP_LEVEL)
-  params:set_action("comp_level", function(value) engine.compLevel(value) end)
+  params:add_control("takt_comp_level", "Comp. level", specs.COMP_LEVEL)
+  params:set_action("takt_comp_level", function(value) engine.compLevel(value) end)
 
 
-  params:add_control("comp_mix", "Comp. dry/wet", specs.COMP_MIX, Formatters.percentage)
-  params:set_action("comp_mix", function(value) engine.compMix(value) end)
+  params:add_control("takt_comp_mix", "Comp. dry/wet", specs.COMP_MIX, Formatters.percentage)
+  params:set_action("takt_comp_mix", function(value) engine.compMix(value) end)
 
-  params:add_control("comp_threshold", "Comp. threshold", specs.COMP_THRESHOLD)
-  params:set_action("comp_threshold", function(value) engine.compThreshold(value) end)
+  params:add_control("takt_comp_threshold", "Comp. threshold", specs.COMP_THRESHOLD)
+  params:set_action("takt_comp_threshold", function(value) engine.compThreshold(value) end)
 
   params:add_control("comp_slopebelow", "Comp. slope below", specs.COMP_SLOPEBELOW)
   params:set_action("comp_slopebelow", function(value) engine.compSlopeBelow(value) end)

--- a/lib/ui.lua
+++ b/lib/ui.lua
@@ -1127,8 +1127,8 @@ function ui.draw_comp(x, y, index)
   screen.rect(x - 1, y - 1, w + 1, 7)
   screen.fill()
 
-  local level = util.linlin(-99, 6, 0, 34, params:get('comp_level'))
-  local threshold = util.linexp(0, 1, 5, 15, params:get('comp_threshold'))
+  local level = util.linlin(-99, 6, 0, 34, params:get('takt_comp_level'))
+  local threshold = util.linexp(0, 1, 5, 15, params:get('takt_comp_threshold'))
   local slope_b = util.linlin(0, 1, 0, 10, params:get('comp_slopebelow'))
   local slope_a = util.linlin(0, 1, 0, 10, params:get('comp_slopeabove'))
   local attack = util.linlin(0, 1, 3, 20, params:get('comp_clamptime'))
@@ -1239,8 +1239,8 @@ end
 function ui.patterns(pattern, metaseq, ui_index, stage)
   local tile = { 
 
-    {1, 'VOL', function(i,n) ui.draw_level_meter(1, 8, -99, 6,    params:get('comp_level'), i,  ui_index, false, n) end},
-    {2, 'MIX', function(i,n) ui.draw_level_meter(1, 26, -1, 1,    params:get('comp_mix'), 2, ui_index, false, n)    end},
+    {1, 'VOL', function(i,n) ui.draw_level_meter(1, 8, -99, 6,    params:get('takt_comp_level'), i,  ui_index, false, n) end},
+    {2, 'MIX', function(i,n) ui.draw_level_meter(1, 26, -1, 1,    params:get('takt_comp_mix'), 2, ui_index, false, n)    end},
     {4, 'TIME', function(i,n) ui.draw_level_meter(64, 8, 0.1, 60, params:get('reverb_time'), 8,  ui_index, false, n) end},
     {10,'SIZE', function(i,n) ui.draw_level_meter(64, 26, 0, 5,   params:get('reverb_size'), 9,  ui_index, false, n) end},
 

--- a/takt.lua
+++ b/takt.lua
@@ -133,14 +133,14 @@ local prev_level_val = 0
 local function comp_shut(state)
     if state then
         print('run')
-        params:set('comp_mix', prev_mix_val)
-        params:set('comp_level', prev_level_val)
+        params:set('takt_comp_mix', prev_mix_val)
+        params:set('takt_comp_level', prev_level_val)
     elseif not state then 
         print('stop')
-        prev_mix_val = params:get('comp_mix')
-        prev_level_val = params:get('comp_level')
-        params:set('comp_mix', -1)
-        params:set('comp_level', -99)
+        prev_mix_val = params:get('takt_comp_mix')
+        prev_level_val = params:get('takt_comp_level')
+        params:set('takt_comp_mix', -1)
+        params:set('takt_comp_level', -99)
     end
 
 end
@@ -829,11 +829,11 @@ local controls = {
 }
 
 local params_fx = {
-  [1] = function(d) params:set('comp_level', params:get('comp_level') + d) end,
-  [2] = function(d) params:set('comp_mix', params:get('comp_mix') + d / 50) end,
+  [1] = function(d) params:set('takt_comp_level', params:get('takt_comp_level') + d) end,
+  [2] = function(d) params:set('takt_comp_mix', params:get('takt_comp_mix') + d / 50) end,
   [3] = function(d)
-    local val = threshold_map:unmap(params:get('comp_threshold'))
-    params:set('comp_threshold', threshold_map:map(util.clamp(val + d /200, 0.001, 1 ))) 
+    local val = threshold_map:unmap(params:get('takt_comp_threshold'))
+    params:set('takt_comp_threshold', threshold_map:map(util.clamp(val + d /200, 0.001, 1 ))) 
   end, 
   [4] = function(d) params:set('comp_slopebelow', params:get('comp_slopebelow') + d / 100) end,
   [5] = function(d) params:set('comp_slopeabove', params:get('comp_slopeabove') + d / 100) end,


### PR DESCRIPTION
Hello, 
Love this script! Norns update 220129 seems to have broken it due to takt overwriting certain compressor parameter names. (See [norns: update 220129 on lines forum](https://llllllll.co/t/norns-update-220129/52355)[](https://llllllll.co/c/monome/9))

I've just appended `takt_` to the offending parameter id's.

Tested on a fates running the most recent norns update. The original parameter names hung takt on launch.
